### PR TITLE
Do not pass `null` to the `$text` parameter of adapter's `notify()`

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -42,7 +42,7 @@ class ProgressBar
      *
      * @var string
      */
-    protected $statusText = null;
+    protected $statusText = '';
 
     /**
      * Adapter for the output

--- a/test/ProgressBarTest.php
+++ b/test/ProgressBarTest.php
@@ -80,6 +80,13 @@ class ProgressBarTest extends TestCase
         $this->assertEquals(null, $progressBar->getTimeRemaining());
     }
 
+    public function testMissingTextIsNotNull()
+    {
+        $progressBar = $this->_getProgressBar(0, 100);
+
+        $this->assertSame('', $progressBar->getText());
+    }
+
     // @codingStandardsIgnoreStart
     protected function _getProgressBar($min, $max, $persistenceNamespace = null)
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The `$text` parameter is documented to take a `string`, not a `?string` and in
fact the Console adapter unconditionally calls a variant of `substr()` on the
given `$text` to shorten it to the configured display width.

With PHP 8.1 this fails, because native functions no longer accept `null` for a
string parameter:

> TypeError: grapheme_substr(): Argument #1 ($string) must be of type string, null given in […]
