### PR TITLE
Add support for PHP 8.2 to composer.json

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,5 @@
+{
+    "ignore_php_platform_requirements": {
+        "8.2": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,10 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-json": "^3.3",
         "laminas/laminas-session": "^2.13",
         "phpunit/phpunit": "^9.5.25"
     },
     "suggest": {
-        "laminas/laminas-json": "Laminas\\Json component",
         "laminas/laminas-session": "To support progressbar persistent"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "laminas/laminas-stdlib": "^3.2.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42f3f957050b7e2ad6451be95092cb6f",
+    "content-hash": "fac6f00293ca26f98f91b49cd74f6b7c",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -181,32 +181,33 @@
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.5.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "41f7209428f37cab9573365e361f4078209aaafa"
+                "reference": "3f1afbad86cd34a431fdc069f265cfe6f8fc8308"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/41f7209428f37cab9573365e361f4078209aaafa",
-                "reference": "41f7209428f37cab9573365e361f4078209aaafa",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/3f1afbad86cd34a431fdc069f265cfe6f8fc8308",
+                "reference": "3f1afbad86cd34a431fdc069f265cfe6f8fc8308",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2",
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-stdlib": "^3.6",
-                "phpbench/phpbench": "^1.1",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.5",
-                "psr/container": "^1.1.2 || ^2.0.2"
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-stdlib": "^3.15",
+                "phpbench/phpbench": "^1.2.6",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "psr/container": "^1.1.2 || ^2.0.2",
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
@@ -244,68 +245,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-04-06T21:05:17+00:00"
-        },
-        {
-            "name": "laminas/laminas-json",
-            "version": "3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-json.git",
-                "reference": "9a0ce9f330b7d11e70c4acb44d67e8c4f03f437f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/9a0ce9f330b7d11e70c4acb44d67e8c4f03f437f",
-                "reference": "9a0ce9f330b7d11e70c4acb44d67e8c4f03f437f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "conflict": {
-                "zendframework/zend-json": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "laminas/laminas-json-server": "For implementing JSON-RPC servers",
-                "laminas/laminas-xml2json": "For converting XML documents to JSON"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Json\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "json",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-json/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-json/issues",
-                "rss": "https://github.com/laminas/laminas-json/releases.atom",
-                "source": "https://github.com/laminas/laminas-json"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-09-02T18:02:31+00:00"
+            "time": "2022-10-11T12:46:13+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fac6f00293ca26f98f91b49cd74f6b7c",
+    "content-hash": "606503e7b0bf4a98949a4c39ede56e6c",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -2280,7 +2280,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/src/Adapter/JsPull.php
+++ b/src/Adapter/JsPull.php
@@ -4,6 +4,8 @@ namespace Laminas\ProgressBar\Adapter;
 
 use function json_encode;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * Laminas\ProgressBar\Adapter\JsPull offers a simple method for updating a
  * progressbar in a browser.
@@ -51,7 +53,7 @@ class JsPull extends AbstractAdapter
             'finished'      => false
         ];
 
-        $data = json_encode($arguments);
+        $data = json_encode($arguments, JSON_THROW_ON_ERROR);
 
         // Output the data
         $this->_outputData($data);
@@ -64,7 +66,7 @@ class JsPull extends AbstractAdapter
      */
     public function finish()
     {
-        $data = json_encode(['finished' => true]);
+        $data = json_encode(['finished' => true], JSON_THROW_ON_ERROR);
 
         $this->_outputData($data);
     }

--- a/src/Adapter/JsPull.php
+++ b/src/Adapter/JsPull.php
@@ -2,7 +2,7 @@
 
 namespace Laminas\ProgressBar\Adapter;
 
-use Laminas\Json\Json;
+use function json_encode;
 
 /**
  * Laminas\ProgressBar\Adapter\JsPull offers a simple method for updating a
@@ -51,7 +51,7 @@ class JsPull extends AbstractAdapter
             'finished'      => false
         ];
 
-        $data = Json::encode($arguments);
+        $data = json_encode($arguments);
 
         // Output the data
         $this->_outputData($data);
@@ -64,7 +64,7 @@ class JsPull extends AbstractAdapter
      */
     public function finish()
     {
-        $data = Json::encode(['finished' => true]);
+        $data = json_encode(['finished' => true]);
 
         $this->_outputData($data);
     }

--- a/src/Adapter/JsPush.php
+++ b/src/Adapter/JsPush.php
@@ -4,6 +4,8 @@ namespace Laminas\ProgressBar\Adapter;
 
 use function json_encode;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * Laminas\ProgressBar\Adapter\JsPush offers a simple method for updating a
  * progressbar in a browser.
@@ -73,7 +75,7 @@ class JsPush extends AbstractAdapter
         ];
 
         $data = '<script type="text/javascript">'
-              . 'parent.' . $this->updateMethodName . '(' . json_encode($arguments) . ');'
+              . 'parent.' . $this->updateMethodName . '(' . json_encode($arguments, JSON_THROW_ON_ERROR) . ');'
               . '</script>';
 
         // Output the data

--- a/src/Adapter/JsPush.php
+++ b/src/Adapter/JsPush.php
@@ -2,7 +2,7 @@
 
 namespace Laminas\ProgressBar\Adapter;
 
-use Laminas\Json\Json;
+use function json_encode;
 
 /**
  * Laminas\ProgressBar\Adapter\JsPush offers a simple method for updating a
@@ -73,7 +73,7 @@ class JsPush extends AbstractAdapter
         ];
 
         $data = '<script type="text/javascript">'
-              . 'parent.' . $this->updateMethodName . '(' . Json::encode($arguments) . ');'
+              . 'parent.' . $this->updateMethodName . '(' . json_encode($arguments) . ');'
               . '</script>';
 
         // Output the data

--- a/test/Adapter/JsPullTest.php
+++ b/test/Adapter/JsPullTest.php
@@ -5,6 +5,8 @@ namespace LaminasTest\ProgressBar\Adapter;
 use LaminasTest\ProgressBar\TestAsset\JsPullStub;
 use PHPUnit\Framework\TestCase;
 
+use const JSON_THROW_ON_ERROR;
+
 class JsPullTest extends TestCase
 {
     public function testJson()
@@ -13,7 +15,7 @@ class JsPullTest extends TestCase
         $adapter->notify(0, 2, 0.5, 1, 1, 'status');
         $output = $adapter->getLastOutput();
 
-        $data = json_decode($output, true);
+        $data = json_decode($output, true, JSON_THROW_ON_ERROR);
 
         $this->assertEquals(0, $data['current']);
         $this->assertEquals(2, $data['max']);
@@ -26,7 +28,7 @@ class JsPullTest extends TestCase
         $adapter->finish();
         $output = $adapter->getLastOutput();
 
-        $data = json_decode($output, true);
+        $data = json_decode($output, true, JSON_THROW_ON_ERROR);
 
         $this->assertTrue($data['finished']);
     }

--- a/test/Adapter/JsPushTest.php
+++ b/test/Adapter/JsPushTest.php
@@ -5,6 +5,8 @@ namespace LaminasTest\ProgressBar\Adapter;
 use LaminasTest\ProgressBar\TestAsset\JsPushStub;
 use PHPUnit\Framework\TestCase;
 
+use const JSON_THROW_ON_ERROR;
+
 class JsPushTest extends TestCase
 {
     public function testJson()
@@ -19,7 +21,7 @@ class JsPushTest extends TestCase
             . preg_quote('Laminas\\ProgressBar\\ProgressBar\\Update') . '\((.*?)\);</script>#', $output, $result);
         $this->assertEquals(1, $matches);
 
-        $data = json_decode($result[1], true);
+        $data = json_decode($result[1], true, JSON_THROW_ON_ERROR);
 
         $this->assertEquals(0, $data['current']);
         $this->assertEquals(2, $data['max']);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

No code change needed, all tests passed locally. My understanding is that CI will automatically run tests for all versions in composer.json.

Furthermore my understanding of the last TSC meeting is that “security only” is redefined to “passive maintenance”, this change should qualify for that.