### PR TITLE
Revert "Ignore PHP 8.2 platform requirements via .laminas-ci.json"

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,5 +1,0 @@
-{
-    "ignore_php_platform_requirements": {
-        "8.2": true
-    }
-}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This is no longer necessary, because all requirements are updated.

This reverts commit d301f41923d26dc640155b5576b68b778be85450.